### PR TITLE
vnstati: fivegraph limit with unlimited retention

### DIFF
--- a/src/vnstati.c
+++ b/src/vnstati.c
@@ -386,7 +386,7 @@ void parseargs(IPARAMS *p, IMAGECONTENT *ic, int argc, char **argv)
 				if (cfg.fivegresultcount < FIVEGMINRESULTCOUNT) {
 					printf("Error: Invalid limit parameter \"%s\" for %s. A value equal or over %d is expected.\n", argv[currentarg + 1], argv[currentarg], FIVEGMINRESULTCOUNT);
 					exit(EXIT_FAILURE);
-				} else if (cfg.fivegresultcount > cfg.fiveminutehours * 12) {
+				} else if (cfg.fivegresultcount > cfg.fiveminutehours * 12 && cfg.fiveminutehours > 0) {
 					printf("Error: Invalid limit parameter \"%s\" for %s. Value cannot be larger than configured data retention (5MinuteHours %d * 12 = %d).\n", argv[currentarg + 1], argv[currentarg], cfg.fiveminutehours, cfg.fiveminutehours * 12);
 					exit(EXIT_FAILURE);
 				}


### PR DESCRIPTION
When using unlimited retention of 5 minute intervals, you could not modify the limit and heigth of the fivegraph output because range checking for the fivegraph limit does not account for -1 as configured retention hours.
This commit changes the range check by requiring that retention hours are positive before limiting them to the configured retention.
I'm assuming that any negative values other than -1 either have the same "unlimited" effect or are caught in vnstatd.